### PR TITLE
Reduce CPU count to 1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ vm_timezone  = "US/Eastern"
 vm_current_version = "v0.2.0"
 vm_name = "Lucee-Dev-#{vm_current_version}"
 vm_max_memory = 4096
-vm_num_cpus = 2
+vm_num_cpus = 1
 vm_max_host_cpu_cap = "30"
 
 # database configuration


### PR DESCRIPTION
My recent experience is that reducing the Virtual CPU setting speeds up performance considerably. This appears to be supported by other articles out there on the interwebs. I'm proposing it as a change to your template since I have used it as a reference point a lot. Test the change and see if you see a performance improvement too.

For more information see:
https://ruin.io/2014/benchmarking-virtualbox-multiple-core-performance/
https://github.com/roots/trellis/issues/410
